### PR TITLE
fix

### DIFF
--- a/db/package/util.py
+++ b/db/package/util.py
@@ -28,7 +28,7 @@ class IOUtil:
 
     @staticmethod
     def get_some_discord_accounts(
-            db: Session, discord_ids: list[int]
+        db: Session, discord_ids: list[int]
     ) -> ScalarResult[DiscordAccount]:
         return (
             db.execute(
@@ -46,7 +46,7 @@ class IOUtil:
 
     @staticmethod
     def create_discord_account(
-            db: Session, acc: schemas.DiscordAccountSchema
+        db: Session, acc: schemas.DiscordAccountSchema
     ) -> DiscordAccount:
         discord = DiscordAccount(
             discord_id=acc.id, username=acc.username, avatar=acc.avatar
@@ -58,7 +58,7 @@ class IOUtil:
 
     @staticmethod
     def update_discord_account(
-            db: Session, acc: DiscordAccount, new_data: schemas.DiscordAccountSchema
+        db: Session, acc: DiscordAccount, new_data: schemas.DiscordAccountSchema
     ) -> DiscordAccount:
         acc.username = new_data.username
         acc.avatar = new_data.avatar
@@ -84,7 +84,7 @@ class IOUtil:
 
     @staticmethod
     def create_wikidot_account(
-            db: Session, acc: schemas.WikidotAccountSchema
+        db: Session, acc: schemas.WikidotAccountSchema
     ) -> WikidotAccount:
         wd_acc = WikidotAccount(
             wikidot_id=acc.id, username=acc.username, unixname=acc.unixname
@@ -96,10 +96,12 @@ class IOUtil:
 
     @staticmethod
     def update_wikidot_account(
-            db: Session, acc: WikidotAccount, new_data: schemas.WikidotAccountSchema
+        db: Session, acc: WikidotAccount, new_data: schemas.WikidotAccountSchema
     ) -> WikidotAccount:
-        if acc.id != new_data.id:
-            raise ValueError("Wikidot user id is not match in update_wikidot_account")
+        if acc.wikidot_id != new_data.id:
+            raise ValueError(
+                f"Wikidot user id is not match in update_wikidot_account / {acc.wikidot_id} / {new_data.id}"
+            )
 
         if acc.username != new_data.username or acc.unixname != new_data.unixname:
             acc.username = new_data.username
@@ -111,7 +113,7 @@ class IOUtil:
 
     @staticmethod
     def create_link(
-            db: Session, dc_acc: DiscordAccount, wd_acc: WikidotAccount
+        db: Session, dc_acc: DiscordAccount, wd_acc: WikidotAccount
     ) -> LinkedAccount | None:
         # 存在チェック
         link = (
@@ -140,7 +142,7 @@ class IOUtil:
 
     @staticmethod
     def get_discord_account_from_token(
-            db: Session, token: str
+        db: Session, token: str
     ) -> DiscordAccount | None:
         # 10分以内のトークンを取得
         token = (
@@ -178,7 +180,7 @@ class IOUtil:
 
     @staticmethod
     def update_jp_member(
-            db: Session, client: wikidot.Client, user: WikidotAccount
+        db: Session, client: wikidot.Client, user: WikidotAccount
     ) -> WikidotAccount:
         site = client.site.get("scp-jp")
         user.is_jp_member = site.member_lookup(user.username, user.wikidot_id)


### PR DESCRIPTION
- **Bump boto3 from 1.35.76 to 1.35.77**
- **remove pickle**
- **add env**
- **Bump boto3 from 1.35.77 to 1.35.79**
- **Bump boto3 from 1.35.79 to 1.35.80**
- **Bump newrelic from 10.3.1 to 10.4.0**
- **Bump boto3 from 1.35.80 to 1.35.81**
- **Bump pydantic from 2.10.3 to 2.10.4**
- **Bump mypy from 1.13.0 to 1.14.0**
- **Bump jinja2 from 3.1.4 to 3.1.5**
- **Bump boto3 from 1.35.81 to 1.35.87**
- **Bump mypy from 1.14.0 to 1.14.1**
- **Bump boto3 from 1.35.87 to 1.35.90**
- **Bump boto3 from 1.35.90 to 1.35.91**
- **Bump boto3 from 1.35.91 to 1.35.92**
- **Bump pydantic from 2.10.4 to 2.10.5**
- **Bump boto3 from 1.35.92 to 1.35.95**
- **Bump boto3 from 1.35.95 to 1.35.96**
- **Bump sqlalchemy from 2.0.36 to 2.0.37**
- **Bump boto3 from 1.35.96 to 1.35.97**
- **Bump boto3 from 1.35.97 to 1.35.98**
- **Bump sentry-sdk from 2.19.2 to 2.20.0**
- **Bump boto3 from 1.35.98 to 1.35.99**
- **Bump boto3 from 1.35.99 to 1.36.0**
- **Bump boto3 from 1.36.0 to 1.36.1**
- **fix: downgrade boto3 to 1.35.99**
- **fix: downgrade boto3 to 1.35.99**
- **Bump alembic from 1.14.0 to 1.14.1**
- **add: dumper test**
- **fix**
- **update ci**
- **format and lint**
- **update all**
- **update ci**
- **test**
- **makefile**
- **makefile**
- **makefile**
- **Bump ruff from 0.9.2 to 0.9.3**
- **Bump pydantic from 2.10.5 to 2.10.6**
- **Bump newrelic from 10.4.0 to 10.5.0**
- **Bump fastapi from 0.115.7 to 0.115.8**
- **Bump ruff from 0.9.3 to 0.9.4**
- **Bump python from 3.12.7-slim to 3.13.2-slim in /db**
- **Bump python from 3.12.7-slim to 3.13.2-slim in /server**
- **Bump newrelic from 10.5.0 to 10.6.0**
- **Bump sqlalchemy from 2.0.37 to 2.0.38**
- **Bump ruff from 0.9.4 to 0.9.5**
- **fix callback**
- **fix callback**
